### PR TITLE
Fixed window size comparison being invalid when dictionary contains extra info

### DIFF
--- a/applitools/_viewport_size.py
+++ b/applitools/_viewport_size.py
@@ -69,7 +69,8 @@ def set_viewport_size(driver, required_size):
             driver.set_window_size(required_browser_size['width'], required_browser_size['height'])
             time.sleep(_BROWSER_STABILIZATION_WAIT)
             browser_size = driver.get_window_size()
-            if browser_size == required_browser_size:
+            if (browser_size['width'] == required_browser_size['width'] and
+                   browser_size['height'] == required_browser_size['height']):
                 break
             logger.debug("Current browser size: {}".format(browser_size))
         else:


### PR DESCRIPTION
**Getting window size from selenium driver returns:**
```
{"width":1024,"hCode":4194304,"class":"org.openqa.selenium.Dimension","height":768}
```

**Which compared to:**
```
{"width": 1024, "height": 768}
```

Returns false.

This PR addresses this by instead directly comparing the height & width components without comparing other fields in  the dictionary (such as class / hCode).  This could be done in other ways as well but this was the least frictional.  This is certainly a defect that has prohibited us @ TE2 from capturing images using Robot-AppEyes on all browser except Chrome (who doesn't include the other information).