### PR TITLE
Fix of User can't use ActionChains with EyesWebDriver issue

### DIFF
--- a/applitools/_webdriver.py
+++ b/applitools/_webdriver.py
@@ -577,7 +577,7 @@ class EyesWebDriver(object):
                             'desired_capabilities', 'log_types', 'name', 'page_source', 'title',
                             'window_handles', 'switch_to', 'mobile', 'current_context', 'context',
                             'current_activity', 'network_connection', 'available_ime_engines',
-                            'active_ime_engine', 'device_time']
+                            'active_ime_engine', 'device_time', 'w3c']
     _SETTABLE_PROPERTIES = ['orientation']
 
     # This should pretty much cover all scroll bars (and some fixed position footer elements :) ).


### PR DESCRIPTION
Fixing [User can't use ActionChains with EyesWebDriver](https://github.com/applitools/eyes.selenium.python/issues/3)

I just added w3c attribute to list of possible EyesDriverProperties. If origin selenium driver has that set it will be set on EyesWebdriverInstance as well and it will be used properly with newest Selenium python bindings