### PR TITLE
Return actual viewport size from Eyes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ applitools/__pycache__/
 applitools/utils/__pycache__/
 dist/
 test/__pycache__/
+.envrc
+.pytest_cache/
+geckodriver.log

--- a/applitools/eyes.py
+++ b/applitools/eyes.py
@@ -334,7 +334,7 @@ class Eyes(object):
         :return: ({width, height}) The size of the viewport of the application under test (e.g,
                                 the browser).
         """
-        return self._viewport_size
+        return self._driver.get_viewport_size()
 
     def abort_if_not_closed(self):
         """

--- a/test/server_results_text.py
+++ b/test/server_results_text.py
@@ -58,3 +58,11 @@ def test_summary_status_diffsfound(eyes, driver):
         eyes.close()
 
 
+def test_directly_set_viewport_size(eyes, driver):
+    required_viewport = {'width': 450, 'height': 300}
+    eyes.set_viewport_size(driver, required_viewport)
+    driver = eyes.open(driver, "Python SDK", "TestViewPort-DirectlySetViewportt")
+    assert required_viewport == eyes.get_viewport_size()
+    assert required_viewport == driver.get_viewport_size()
+
+


### PR DESCRIPTION
* Eyes instance get_viewport_size() return actual viewport_size from the
driver
* Add test_directly_set_viewport_size